### PR TITLE
Lock Travis build to master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 language: php
 
 php:


### PR DESCRIPTION
This will avoid double Travis instance on Pull Requests.