### PR TITLE
renaming nexy_slack.client service to Nexy\Slack\Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add client service autowiring
 
 ## [2.1.0]
 ### Added

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,17 +5,12 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" class="Nexy\Slack\Client" public="true">
+        <service id="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client"/>
         </service>
 
-        <service id="nexy_slack.client" class="Nexy\Slack\Client" public="true">
-            <argument>%nexy_slack.endpoint%</argument>
-            <argument>%nexy_slack.config%</argument>
-            <argument type="service" id="nexy_slack.http.client"/>
-            <deprecated>The "%service_id%" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
-        </service>
+        <service id="nexy_slack.client" alias="Nexy\Slack\Client"/>
     </services>
 </container>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -10,8 +10,13 @@
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client"/>
         </service>
-        <service id="nexy_slack.client" alias="Nexy\Slack\Client">
-            <deprecated>The "%service_id%" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
+
+        <service id="nexy_slack.client" class="Nexy\Slack\Client" public="true">
+            <argument>%nexy_slack.endpoint%</argument>
+            <argument>%nexy_slack.config%</argument>
+            <argument type="service" id="nexy_slack.http.client"/>
+            <deprecated>The "%service_id%" service is deprecated since symfony v4.0,
+                use "Nexy\Slack\Client" instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,12 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" public="true">
-            <argument>%nexy_slack.endpoint%</argument>
-            <argument>%nexy_slack.config%</argument>
-            <argument type="service" id="nexy_slack.http.client"/>
-        </service>
-
+        <service id="Nexy\Slack\Client" alias="nexy_slack.client" />
         <service id="nexy_slack.client" class="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" class="Nexy\Slack\Client" public="true">
+        <service id="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client"/>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -11,7 +11,7 @@
             <argument type="service" id="nexy_slack.http.client"/>
         </service>
         <service id="nexy_slack.client" alias="Nexy\Slack\Client">
-            <deprecated>The "nexy_slack.client" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="nexy_slack.client" class="Nexy\Slack\Client" public="true">
+        <service id="Nexy\Slack\Client" class="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client" />

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -15,8 +15,7 @@
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client"/>
-            <deprecated>The "%service_id%" service is deprecated since symfony v4.0,
-                use "Nexy\Slack\Client" instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -8,7 +8,7 @@
         <service id="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
-            <argument type="service" id="nexy_slack.http.client"/>
+            <argument type="service" id="nexy_slack.http.client" />
         </service>
 
         <service id="nexy_slack.client" alias="Nexy\Slack\Client"/>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" public="true">
+        <service id="Nexy\Slack\Client" class="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client"/>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,7 +5,12 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" alias="nexy_slack.client" />
+        <service id="Nexy\Slack\Client" class="Nexy\Slack\Client" public="true">
+            <argument>%nexy_slack.endpoint%</argument>
+            <argument>%nexy_slack.config%</argument>
+            <argument type="service" id="nexy_slack.http.client"/>
+        </service>
+
         <service id="nexy_slack.client" class="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -11,9 +11,6 @@
             <argument type="service" id="nexy_slack.http.client"/>
         </service>
         <service id="nexy_slack.client" alias="Nexy\Slack\Client">
-            <argument>%nexy_slack.endpoint%</argument>
-            <argument>%nexy_slack.config%</argument>
-            <argument type="service" id="nexy_slack.http.client"/>
             <deprecated>The "nexy_slack.client" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
         </service>
     </services>

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,10 +5,16 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" class="Nexy\Slack\Client" public="true">
+        <service id="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
-            <argument type="service" id="nexy_slack.http.client" />
+            <argument type="service" id="nexy_slack.http.client"/>
+        </service>
+        <service id="nexy_slack.client" alias="Nexy\Slack\Client">
+            <argument>%nexy_slack.endpoint%</argument>
+            <argument>%nexy_slack.config%</argument>
+            <argument type="service" id="nexy_slack.http.client"/>
+            <deprecated>The "nexy_slack.client" service is deprecated since symfony v4.0, use "Nexy\Slack\Client" instead.</deprecated>
         </service>
     </services>
 </container>

--- a/tests/DependencyInjection/NexySlackExtensionTest.php
+++ b/tests/DependencyInjection/NexySlackExtensionTest.php
@@ -47,7 +47,7 @@ class NexySlackExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('nexy_slack.endpoint', $endpoint);
         $this->assertContainerBuilderHasParameter('nexy_slack.config', $slackConfig);
 
-        $this->assertContainerBuilderHasService('Nexy\Slack\Client', Client::class);
+        $this->assertContainerBuilderHasService('Nexy\Slack\Client');
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 0, '%nexy_slack.endpoint%');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 1, '%nexy_slack.config%');

--- a/tests/DependencyInjection/NexySlackExtensionTest.php
+++ b/tests/DependencyInjection/NexySlackExtensionTest.php
@@ -46,11 +46,11 @@ class NexySlackExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('nexy_slack.endpoint', $endpoint);
         $this->assertContainerBuilderHasParameter('nexy_slack.config', $slackConfig);
 
-        $this->assertContainerBuilderHasService('nexy_slack.client', Client::class);
+        $this->assertContainerBuilderHasService('Nexy\Slack\Client', Client::class);
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nexy_slack.client', 0, '%nexy_slack.endpoint%');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nexy_slack.client', 1, '%nexy_slack.config%');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nexy_slack.client', 2, new Reference('nexy_slack.http.client'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 0, '%nexy_slack.endpoint%');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 1, '%nexy_slack.config%');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 2, new Reference('nexy_slack.http.client'));
 
         $this->assertContainerBuilderHasAlias('nexy_slack.http.client', 'httplug.client');
     }

--- a/tests/DependencyInjection/NexySlackExtensionTest.php
+++ b/tests/DependencyInjection/NexySlackExtensionTest.php
@@ -53,6 +53,7 @@ class NexySlackExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 1, '%nexy_slack.config%');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 2, new Reference('nexy_slack.http.client'));
 
+        $this->assertContainerBuilderHasAlias('nexy_slack.client', 'Nexy\Slack\Client');
         $this->assertContainerBuilderHasAlias('nexy_slack.http.client', 'httplug.client');
     }
 

--- a/tests/DependencyInjection/NexySlackExtensionTest.php
+++ b/tests/DependencyInjection/NexySlackExtensionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Nexy\SlackBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Nexy\Slack\Client;
 use Nexy\SlackBundle\DependencyInjection\NexySlackExtension;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Reference;

--- a/tests/DependencyInjection/NexySlackExtensionTest.php
+++ b/tests/DependencyInjection/NexySlackExtensionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nexy\SlackBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Nexy\Slack\Client;
 use Nexy\SlackBundle\DependencyInjection\NexySlackExtension;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Reference;
@@ -46,13 +47,13 @@ class NexySlackExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('nexy_slack.endpoint', $endpoint);
         $this->assertContainerBuilderHasParameter('nexy_slack.config', $slackConfig);
 
-        $this->assertContainerBuilderHasService('Nexy\Slack\Client');
+        $this->assertContainerBuilderHasService(Client::class);
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 0, '%nexy_slack.endpoint%');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 1, '%nexy_slack.config%');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('Nexy\Slack\Client', 2, new Reference('nexy_slack.http.client'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(Client::class, 0, '%nexy_slack.endpoint%');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(Client::class, 1, '%nexy_slack.config%');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(Client::class, 2, new Reference('nexy_slack.http.client'));
 
-        $this->assertContainerBuilderHasAlias('nexy_slack.client', 'Nexy\Slack\Client');
+        $this->assertContainerBuilderHasAlias('nexy_slack.client', Client::class);
         $this->assertContainerBuilderHasAlias('nexy_slack.http.client', 'httplug.client');
     }
 


### PR DESCRIPTION
Renaming service in config to comply with Symfony 4.0 as stated in #29.