### PR TITLE
Rollback to the actual service id as a snake-case version

### DIFF
--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -5,12 +5,12 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Nexy\Slack\Client" public="true">
+        <service id="nexy_slack.client" class="Nexy\Slack\Client" public="true">
             <argument>%nexy_slack.endpoint%</argument>
             <argument>%nexy_slack.config%</argument>
             <argument type="service" id="nexy_slack.http.client" />
         </service>
 
-        <service id="nexy_slack.client" alias="Nexy\Slack\Client"/>
+        <service id="Nexy\Slack\Client" alias="nexy_slack.client"/>
     </services>
 </container>

--- a/tests/DependencyInjection/NexySlackExtensionTest.php
+++ b/tests/DependencyInjection/NexySlackExtensionTest.php
@@ -47,13 +47,13 @@ class NexySlackExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('nexy_slack.endpoint', $endpoint);
         $this->assertContainerBuilderHasParameter('nexy_slack.config', $slackConfig);
 
-        $this->assertContainerBuilderHasService(Client::class);
+        $this->assertContainerBuilderHasService('nexy_slack.client');
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(Client::class, 0, '%nexy_slack.endpoint%');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(Client::class, 1, '%nexy_slack.config%');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(Client::class, 2, new Reference('nexy_slack.http.client'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nexy_slack.client', 0, '%nexy_slack.endpoint%');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nexy_slack.client', 1, '%nexy_slack.config%');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nexy_slack.client', 2, new Reference('nexy_slack.http.client'));
 
-        $this->assertContainerBuilderHasAlias('nexy_slack.client', Client::class);
+        $this->assertContainerBuilderHasAlias(Client::class, 'nexy_slack.client');
         $this->assertContainerBuilderHasAlias('nexy_slack.http.client', 'httplug.client');
     }
 


### PR DESCRIPTION
Related PR: #31

As proposed by @weaverryan here: https://github.com/nexylan/slack-bundle/pull/31/files#r334506538

> This really should have been done in the other direction: we typically make the actual service id the snake-case version and then create an alias for the autowiring.