### PR TITLE
bumped php-http/httplug-bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1",
         "nexylan/slack": "^2.2",
-        "php-http/httplug-bundle": "^1.8",
+        "php-http/httplug-bundle": "^1.17",
         "symfony/http-kernel": "^3.4 || ^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
php-http/httplug-bundle v 1.8 conflicts with twig 3.0. In order to use twig 3.0 we need to update php-http/httplug-bundle to 1.17