### PR TITLE
Forcing php-http/httplug version 2 to get PSR interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,18 @@
     "require": {
         "php": "^7.3",
         "nexylan/slack": "^3.0",
+        "php-http/discovery": "^1.6",
         "php-http/httplug-bundle": "^1.17",
         "php-http/httplug": "^2.0",
         "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
+        "http-interop/http-factory-guzzle": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "php-http/guzzle6-adapter": "^1.1.1 || ^2.0",
         "php-http/mock-client": "^1.1",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0",
+        "symfony/framework-bundle": "^3.4 || ^4.4 || ^5.0"
     },
     "suggest": {
         "eightpoints/guzzle-bundle": "Make a custom Guzzle instance for Slack with ease"

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^7.3",
         "nexylan/slack": "^3.0",
         "php-http/httplug-bundle": "^1.17",
+        "php-http/httplug": "^2.0",
         "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Nexylan packages.
+ *
+ * (c) Nexylan SAS <contact@nexylan.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nexy\SlackBundle\Tests;
+
+use Http\HttplugBundle\HttplugBundle;
+use Nexy\Slack\Client;
+use Nexy\SlackBundle\NexySlackBundle;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+class IntegrationTest extends TestCase
+{
+    public function testServiceIntegration(): void
+    {
+        $kernel = new NexySlackIntegrationTestKernel();
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        // sanity check on service wiring
+        $client = $container->get('nexy_slack.client');
+        $this->assertInstanceOf(Client::class, $client);
+    }
+}
+
+abstract class AbstractNexySlackIntegrationTestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', true);
+    }
+
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new NexySlackBundle(),
+            new HttplugBundle(),
+        ];
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $container->loadFromExtension('framework', [
+            'secret' => 'foo',
+        ]);
+
+        $container->loadFromExtension('nexy_slack', [
+            'endpoint' => 'http://localhost',
+        ]);
+    }
+}
+
+if (method_exists(AbstractNexySlackIntegrationTestKernel::class, 'configureRouting')) {
+    class NexySlackIntegrationTestKernel extends AbstractNexySlackIntegrationTestKernel
+    {
+        protected function configureRouting(RoutingConfigurator $routes): void
+        {
+        }
+    }
+} else {
+    class NexySlackIntegrationTestKernel extends AbstractNexySlackIntegrationTestKernel
+    {
+        protected function configureRoutes(RouteCollectionBuilder $routes): void
+        {
+        }
+    }
+}


### PR DESCRIPTION
Hi!

In `nexylan/slack` v3, the http interfaces were changed to PSR instead of http-plug. Thus, we need to *force* httplug v2 in order to get those new interfaces.

I hit this because in an existing app, I upgraded to the latest version if this bundle but did *not* upgrade my http-plug version. Now I'm getting:

> Argument 1 passed to Nexy\Slack\Client::__construct() must be an instance of Psr\Http\Client\ClientInterface, instance of Http\Client\Common\PluginClient given,

This is because I have v1 of `php-http/httplug`, so ultimately the `nexy_slack.http.client` (which points to `httplug.client` by default) will be the HttPlug interface from v1, and not the Psr one from v2.

Cheers!